### PR TITLE
🔧 Review backend workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,20 +23,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.0.0
         with:
           java-version: 17
-          distribution: temurin
-# TODO requires https://github.com/gradle/wrapper-validation-action/issues/59 to be resolved
-#      - name: Validate Gradle Wrapper
-#        uses: gradle/wrapper-validation-action@v1 # https://github.com/marketplace/actions/gradle-wrapper-validation
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3 # https://github.com/marketplace/actions/gradle-build-action
+          distribution: corretto
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2.0.0 # https://github.com/marketplace/actions/gradle-wrapper-validation
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3.0.0 # https://github.com/marketplace/actions/build-with-gradle
         with:
-          build-root-directory: backend
-          arguments: build
+          add-job-summary-as-pr-comment: on-failure
+      - name: Execute Gradle build
+        working-directory: backend
+        run: ./gradlew build
       - name: Create build artifacts
-        uses: actions/upload-artifact@v4 # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v4.3.0 # https://github.com/marketplace/actions/upload-a-build-artifact
         if: always()
         with:
           name: reports


### PR DESCRIPTION
- use gradle/actions/setup-gradle instead of gradle/gradle-build-action
- switch to corretto for gradle build (since the backend runs in AWS)
- add gradle wrapper validation
- use more specific action versions